### PR TITLE
Fixed typo "Map published the BattleNet"

### DIFF
--- a/s2clientprotocol/sc2api.proto
+++ b/s2clientprotocol/sc2api.proto
@@ -160,7 +160,7 @@ enum Status {
 message RequestCreateGame {
   oneof Map {
     LocalMap local_map = 1;                         // Local .SC2Map file
-    string battlenet_map_name = 2;                  // Map published the BattleNet
+    string battlenet_map_name = 2;                  // Map published on BattleNet
   }
 
   repeated PlayerSetup player_setup = 3;

--- a/s2clientprotocol/sc2api.proto
+++ b/s2clientprotocol/sc2api.proto
@@ -160,7 +160,7 @@ enum Status {
 message RequestCreateGame {
   oneof Map {
     LocalMap local_map = 1;                         // Local .SC2Map file
-    string battlenet_map_name = 2;                  // Map published on BattleNet
+    string battlenet_map_name = 2;                  // Map published to BattleNet
   }
 
   repeated PlayerSetup player_setup = 3;


### PR DESCRIPTION
Fixed typo of "Map published the BattleNet" to "Map published to BattleNet" in the descriptive comment for field 'battlenet_map_name' of the RequestCreateGame message object, explaining that the map name has to match one already published on BattleNet.