### PR TITLE
Fix typo "Map published the BattleNet"

### DIFF
--- a/s2clientprotocol/sc2api.proto
+++ b/s2clientprotocol/sc2api.proto
@@ -160,7 +160,7 @@ enum Status {
 message RequestCreateGame {
   oneof Map {
     LocalMap local_map = 1;                         // Local .SC2Map file
-    string battlenet_map_name = 2;                  // Map published the BattleNet
+    string battlenet_map_name = 2;                  // Map published to BattleNet
   }
 
   repeated PlayerSetup player_setup = 3;


### PR DESCRIPTION
Fix typo "Map published the BattleNet" to "Map published to BattleNet" in the descriptive comment for field 'battlenet_map_name' of the RequestCreateGame message object, explaining that the map name has to match one already published to the Battle.net service.

Minor typo, but there's enough complexity in learning the AI API that even an ephemeral confusion would be unwanted.

Official wording uses "publish your maps [...] to the Battle.net service"
http://us.battle.net/sc2/en/game/maps-and-mods/tutorials/publishing/