### PR TITLE
Fix imports to work in python3

### DIFF
--- a/s2clientprotocol/debug.proto
+++ b/s2clientprotocol/debug.proto
@@ -3,7 +3,7 @@ syntax = "proto2";
 
 package SC2APIProtocol;
 
-import "common.proto";
+import "s2clientprotocol/common.proto";
 
 // Issue various useful commands to the game engine.
 message DebugCommand {

--- a/s2clientprotocol/query.proto
+++ b/s2clientprotocol/query.proto
@@ -3,8 +3,8 @@ syntax = "proto2";
 
 package SC2APIProtocol;
 
-import "common.proto";
-import "error.proto";
+import "s2clientprotocol/common.proto";
+import "s2clientprotocol/error.proto";
 
 message RequestQuery {
   repeated RequestQueryPathing pathing = 1;

--- a/s2clientprotocol/raw.proto
+++ b/s2clientprotocol/raw.proto
@@ -3,7 +3,7 @@ syntax = "proto2";
 
 package SC2APIProtocol;
 
-import "common.proto";
+import "s2clientprotocol/common.proto";
 
 //
 // Start

--- a/s2clientprotocol/sc2api.proto
+++ b/s2clientprotocol/sc2api.proto
@@ -3,15 +3,15 @@ syntax = "proto2";
 
 package SC2APIProtocol;
 
-import "common.proto";
-import "data.proto";
-import "debug.proto";
-import "error.proto";
-import "query.proto";
-import "raw.proto";
-import "score.proto";
-import "spatial.proto";
-import "ui.proto";
+import "s2clientprotocol/common.proto";
+import "s2clientprotocol/data.proto";
+import "s2clientprotocol/debug.proto";
+import "s2clientprotocol/error.proto";
+import "s2clientprotocol/query.proto";
+import "s2clientprotocol/raw.proto";
+import "s2clientprotocol/score.proto";
+import "s2clientprotocol/spatial.proto";
+import "s2clientprotocol/ui.proto";
 
 //
 // Notes:

--- a/s2clientprotocol/spatial.proto
+++ b/s2clientprotocol/spatial.proto
@@ -3,7 +3,7 @@ syntax = "proto2";
 
 package SC2APIProtocol;
 
-import "common.proto";
+import "s2clientprotocol/common.proto";
 
 //
 // Observation - Feature Layer

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ class BuildPy(build_py):
 
   def run(self):
     for proto_file in proto_files(PROTO_DIR):
-      compile_proto(proto_file, python_out=PROTO_DIR, proto_path=PROTO_DIR)
+      compile_proto(proto_file, python_out=SETUP_DIR, proto_path=SETUP_DIR)
     with open(os.path.join(PROTO_DIR, '__init__.py'), 'a') as f:
       pass
     build_py.run(self)


### PR DESCRIPTION
I don't see a way to get python3 to import the other compiled proto files without actually changing the imports in the proto themselves. Changing --proto_path only changes where protoc searches, not where python searches. Changing --python_out only changes where it's output, still not where python searches. That leaves either editing the files by hand, or changing the imports. I guess that might mean fixing some c++ imports somewhere as well.