### PR TITLE
Adding build info meta-data from previous builds

### DIFF
--- a/buildinfo/README.md
+++ b/buildinfo/README.md
@@ -1,0 +1,5 @@
+This is build meta-data published with release candidate versions of StarCraft II.
+
+The data-hash is required to start the game manually without using the .build.info file.
+
+Replays set the data-hash automatically based on the replay header.

--- a/buildinfo/versions.json
+++ b/buildinfo/versions.json
@@ -1,0 +1,37 @@
+[
+{
+    "label": "3.16.1",
+    "data-hash": "5bd7c31b44525dab46e64c4602a81dc2",
+    "version": 55958,
+    "fixed-hash": "717b05acd26c108d18a219b03710d06d",
+    "replay-hash": "21c8fa403bb1194e2b6eb7520016b958"
+},
+{
+    "label": "3.16",
+    "data-hash": "60718a7ca50d0df42987a30cf87bcb80",
+    "version": 55505,
+    "fixed-hash": "0189b2804e2f6ba4c4591222089e63b2",
+    "replay-hash": "b11811b13f0c85c29c5d4597bd4ba5a4"
+},
+{
+    "label": "3.15", 
+    "data-hash": "bbf619ccdcc80905350f34c2af0ab4f6",
+    "version": 54518,
+    "fixed-hash": "d5963f25a17d9e1ea406ff6bbaa9b736",
+    "replay-hash": "43530321cf29fd11482ab9cba3eb553d"
+},
+{
+    "label": "3.14",
+    "data-hash": "ca275c4d6e213ed30f80baccdfedb1f5",
+    "version": 53644,
+    "fixed-hash": "29198786619c9011735bcfd378e49cb6",
+    "replay-hash": "5af236fc012adb7289db493e63f73fd5"
+},
+{
+    "label": "3.13",
+    "data-hash": "8d9fef2e1cf7c6c9cbe4fbca830dde1c",
+    "version": 52910,
+    "fixed-hash": "009bc85ef547b51ebf461c83a9cbab30",
+    "replay-hash": "47bfe9d10f26b0a8b74c637d6327bf3c"
+}
+]


### PR DESCRIPTION
This information was retrieved from the import-sc2-rc.psv via t1-ngdpeek.