### PR TITLE
Updates to 'Replay API' README

### DIFF
--- a/samples/replay-api/README.md
+++ b/samples/replay-api/README.md
@@ -1,23 +1,32 @@
 ## Overview
-download_replays.py is for downloading replay packs via Blizzard Game Data APIs.
+`download_replays.py` may be used to download replay packs (aggregated into zip files) via Blizzard Game Data APIs.
 
-## Preliminary
-1. Create an account for calling the APIs in Blizzard Developer Portal(http://dev.battle.net)
-2. Get API key and secret associated with the account
-    You can find them in 'My Account' page after logging into the developer portal
+## Preliminary Setup
+1. Create an account for calling the APIs in the [Blizzard Developer Portal](https://dev.battle.net).
+2. Get API key and secret associated with the account.
+    1. You can find them under the 'My Account' page after logging into the developer portal.
 
 ## Requirements
-The sample script is writting in Python 2.7 and the dependant packages can be installed 
+The script is written in Python 2.7. Dependant packages can be installed via:
 ```
 pip install -r requirements.txt
 ```
 
 ## How to run
-Run download_replays.py with your api key/secret.
+Run `download_replays.py` providing:  
+
+1. API client key `<key>`
+2. API client secret `<secret>`
+3. StarCraft II client version `<version>`
+    1. **Replays are version dependent**. Ensure the version you request is consistent with the build environment in which you intend to utilize them.  
+    2. A version list can be found in [/buildinfo/versions.json](https://github.com/Blizzard/s2client-proto/blob/master/buildinfo/versions.json).  
+4. Local Replay directory for storing the replays. `<directory>`
+
 ```
-    python download_replays.py --client-key=<your_key> --client_secret=<your_secret> --s2-client-version=<s2_client_binary_version> --replays-dir=<the directory where to save replay packs>
+python download_replays.py --client_key=<key> --client_secret=<secret> --s2_client_version=<version> --replays_dir=<directory>
 ```
-Once the script is run successfully, you may find zipped files under the replays-dir if there's any matching replay packs for the given s2 client version.
-To access Starcraft2 replay packs, you must agree to the [AI and Machine Learning License](http://blzdistsc2-a.akamaihd.net/AI_AND_MACHINE_LEARNING_LICENSE.html)
-The files are password protected with the password 'iagreetotheeula'.
-**By typing in the password ‘iagreetotheeula’ you agree to be bound by the terms of the [AI and Machine Learning License](http://blzdistsc2-a.akamaihd.net/AI_AND_MACHINE_LEARNING_LICENSE.html)**
+Once the script is run successfully, any matching replay packs will be downloaded to the directory provided.
+
+To access StarCraft II replay packs, you must agree to the [AI and Machine Learning License](https://blzdistsc2-a.akamaihd.net/AI_AND_MACHINE_LEARNING_LICENSE.html)  
+The files are password protected with the password 'iagreetotheeula'.  
+**By typing in the password ‘iagreetotheeula’ you agree to be bound by the terms of the [AI and Machine Learning License](https://blzdistsc2-a.akamaihd.net/AI_AND_MACHINE_LEARNING_LICENSE.html)**


### PR DESCRIPTION
1. Revision to command line example changing dashes to underscores (consistent with actual download_replay argparse [line 120](https://github.com/Blizzard/s2client-proto/blob/master/samples/replay-api/download_replays.py#L120)
2. Editorial changes to Overview, Setup, and Requirements section
3. Condensed command line example and separated arguments into a list to facilitate single line readability; also making it easier to modify should additional optional argparse commands be added (ex: page_size)
4. Modified all instances of game title to "StarCraft II" per the example usage on the repo README.
5. Moved agreement to AMLL to last line so it's emphasized.
6. Change all links to `https`