### PR TITLE
Fix download script authentication

### DIFF
--- a/samples/replay-api/download_replays.py
+++ b/samples/replay-api/download_replays.py
@@ -21,11 +21,9 @@ class BnetAPI(object):
     def __init__(self, key, secret):
         headers = {"Content-Type": "application/json"}
         params = {
-            "grant_type": "client_credentials",
-            "client_id" : key,
-            "client_secret" : secret,
+            "grant_type": "client_credentials"
         }
-        response = requests.post("https://us.battle.net/oauth/token", headers=headers, params=params)
+        response = requests.post("https://us.battle.net/oauth/token", headers=headers, params=params, auth=requests.auth.HTTPBasicAuth(key, secret))
         if response.status_code != 200:
             raise Exception('Failed to get oauth access token. response={}'.format(response))
         response = json.loads(response.text)

--- a/samples/replay-api/download_replays.py
+++ b/samples/replay-api/download_replays.py
@@ -78,7 +78,7 @@ def download_file(url, output_dir):
 
     response = requests.get(url, stream=True)
     if (not os.path.exists(file_path) or
-        os.path.getsize(file_path) != int(response.headers['Content-Length'])):
+            os.path.getsize(file_path) != int(response.headers['Content-Length'])):
         with open(file_path, 'wb') as f:
             shutil.copyfileobj(response.raw, f)
 
@@ -118,7 +118,7 @@ def main():
             print('Extracting replay pack:', file)
             subprocess.call(['unzip', '-P', 'iagreetotheeula', '-o', '-d', os.path.dirname(file), file])
             if args.remove:
-	            os.remove(file)
+                os.remove(file)
 
 
 def parse_args():
@@ -133,4 +133,4 @@ def parse_args():
 
 
 if __name__ == '__main__':
-  main()
+    main()


### PR DESCRIPTION
The replay download script authentication seems to be broken. According to the blizzard API documentation the credentials should be sent using HTTP authentication fields, not as part of the params (see https://develop.battle.net/documentation/guides/using-oauth/client-credentials-flow).
Changing the code to do this makes it start to work properly for me.

I also made some minor code formatting changes to fix some PEP8 lint errors.