### PR TITLE
Discord Link was dead

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The API is available in the retail Windows and Mac clients. There are also Linux
   * [Website](http://wiki.sc2ai.net/Main_Page)
 * **Discord Server**
   * Unofficial server for discussing AI questions and projects.
-  * [Invite Link](https://discord.gg/qTZ65sh)
+  * [Invite Link](https://discord.gg/BH58ZVt)
 * **Facebook Group**
   * Unofficial community page.
   * [Website](https://www.facebook.com/groups/969196249883813/)


### PR DESCRIPTION
The join Discord link for the unofficial server for AI questions/projects failed to lead to the server.